### PR TITLE
Add Mouse Back Button and Backspace Key Support to Close the Game Info Screen

### DIFF
--- a/jackbox_patcher/lib/components/mouse_back_button_recognizer.dart
+++ b/jackbox_patcher/lib/components/mouse_back_button_recognizer.dart
@@ -1,0 +1,39 @@
+import 'dart:developer';
+
+import 'package:flutter/gestures.dart';
+
+class MouseBackButtonRecognizer extends BaseTapGestureRecognizer {
+  GestureTapDownCallback? onTapDown;
+
+  MouseBackButtonRecognizer({
+    super.debugOwner,
+    super.supportedDevices,
+    super.allowedButtonsFilter,
+  });
+
+  @override
+  void handleTapCancel({
+    required PointerDownEvent down,
+    PointerCancelEvent? cancel,
+    required String reason,
+  }) {}
+
+  @override
+  void handleTapDown({required PointerDownEvent down}) {
+    final TapDownDetails details = TapDownDetails(
+      globalPosition: down.position,
+      localPosition: down.localPosition,
+      kind: getKindForPointer(down.pointer),
+    );
+
+    if (down.buttons == kBackMouseButton && onTapDown != null) {
+      invokeCallback<void>('onTapDown', () => onTapDown!(details));
+    }
+  }
+
+  @override
+  void handleTapUp({
+    required PointerDownEvent down,
+    required PointerUpEvent up,
+  }) {}
+}


### PR DESCRIPTION
### Summary
**This pull request enhances the navigation experience in the game launcher by adding support for closing the game info screen using the mouse back button (standard on many Windows Apps) and the backspace key.**

### How to Test
1. Navigate to the game info screen.
2. Test closing the screen by:
   - Pressing the mouse back button.
   - Pressing the backspace key.
   
### Notes
As this wasn't as straight forward as I thought, I had to add the class `MouseBackButtonRecognizer`, based on [this Flutter Issue](https://github.com/flutter/flutter/issues/115641) where Mouse_Back can't easily be caught. 
I kept it in the same location as the already existing `ClosableRouteWithEsc` class because I wasn't able to find a better suited spot, there might be one though.

The thread also mentions the solution [currently might not work on Linux](https://github.com/flutter/flutter/issues/152128), which might be fixed though. 
Either way, the mouse back button addition shouldn't affect Linux users negatively. 

Thank you for reviewing this pull request, let me know if any changes are required.